### PR TITLE
Add compatibility to Anki 2.1.45+

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -17,7 +17,6 @@ def init(add_cards):
     editor.note.setTagsFromStr(current_note.stringTags())
     editor.updateTags()
     current_did = current_card.odid or current_card.did
-    current_deck = mw.col.decks.get(current_did)
-    add_cards.deckChooser.setDeckName(current_deck["name"])
-    
+    add_cards.deckChooser.selected_deck_id = current_did
+
 gui_hooks.add_cards_did_init.append(init)


### PR DESCRIPTION
Since 2.1.45, the setDeckName() function in deckChooser has been 
removed. An alternative is changing the variable 
deckChooser.selected_deck_id directly to the deck id of the card which 
was currently reviewed.

- tested with Anki 2.1.45b3 and beta 5
- I'm currently not feeling too comfortable in the current codebase, as it's been a while since I've been coding for Anki and I'm only an amateur coder at best. Please confirm that directly accessing and changing the selected_deck_id is the correct way to go about things
- I think the removal of the setDeckName() function occurred with the transition from Anki 2.1.44 -> .45 betas, so versions on AnkiWeb should be set appropriately.

I didn't want to make a pull request at first because I wanted to hear how many people would benefit from it. I'm a bit clumsy with Github and if I'd been the sole user, just doing that change for me personally would have sufficed, without a need for an update on AnkiWeb.