### PR TITLE
Anki 2.1.50 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ It changes `AddCards.__init__`, and call the previous method. In anki
 
 Key         |Value
 ------------|-------------------------------------------------------------------
-Copyright   | Arthur Milchior <arthur@milchior.fr>,
-            | p4nix
+Copyright   | Arthur Milchior <arthur@milchior.fr> <br> p4nix
 Based on    | Anki code by Damien Elmes <anki@ichi2.net>
 License     | GNU GPL, version 3 or later; http://www.gnu.org/licenses/gpl.html
 Source in   | https://github.com/Arthur-Milchior/anki-copy-currentcard-in-add-card

--- a/__init__.py
+++ b/__init__.py
@@ -1,5 +1,6 @@
 from aqt import gui_hooks, mw
 from aqt.addcards import AddCards
+from aqt.utils import tooltip, showInfo
 
 
 def init(add_cards):
@@ -13,10 +14,14 @@ def init(add_cards):
     current_card = reviewer.card
     if current_card is None:
         return
+        
     current_note = current_card.note()
-    editor.note.setTagsFromStr(current_note.stringTags())
-    editor.updateTags()
+    editor.note.tags = current_note.tags
+    showInfo(" ".join(current_note.tags))
     current_did = current_card.odid or current_card.did
     add_cards.deckChooser.selected_deck_id = current_did
+
+    # didn't found other way to update tags, as editor.updateTags() throws error
+    mw.reset()
 
 gui_hooks.add_cards_did_init.append(init)

--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,5 @@
 from aqt import gui_hooks, mw
 from aqt.addcards import AddCards
-from aqt.utils import tooltip, showInfo
-
 
 def init(add_cards):
     editor = add_cards.editor
@@ -14,7 +12,7 @@ def init(add_cards):
     current_card = reviewer.card
     if current_card is None:
         return
-        
+
     current_note = current_card.note()
     editor.note.tags = current_note.tags
     showInfo(" ".join(current_note.tags))


### PR DESCRIPTION
With the editor changes coming to Anki 2.1.50, the editor.updateTags() doesn't work anymore. This change will add compatibility for Anki 2.1.50. I have only tested this change in the pre-released package, other changes may happen as well.

I'm not sure if the changes I've made are backwards compatible, so if you get around to packaging this for AnkiWeb, maybe just let this update happen for Anki 2.1.50. Maybe even wait till the update actually gets released :)

The mw.reset() used for updating tags may not be the best style, I'm too incompetent for the right solution though (not a real programmer).